### PR TITLE
[Feat] Refresh 토큰 쿠키로 변경

### DIFF
--- a/src/main/java/com/a404/duckonback/common/filter/CustomJsonUsernamePasswordAuthenticationFilter.java
+++ b/src/main/java/com/a404/duckonback/common/filter/CustomJsonUsernamePasswordAuthenticationFilter.java
@@ -5,6 +5,7 @@ import com.a404.duckonback.common.enums.UserRole;
 import com.a404.duckonback.common.oauth.userinfo.OAuth2UserInfo;
 import com.a404.duckonback.common.oauth.userinfo.OAuth2UserInfoFactory;
 import com.a404.duckonback.domain.user.repository.UserRepository;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -39,15 +40,26 @@ public class CustomJsonUsernamePasswordAuthenticationFilter extends UsernamePass
     }
 
     @Override
-    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response)
-            throws AuthenticationException {
+    public Authentication attemptAuthentication(
+            HttpServletRequest request,
+            HttpServletResponse response
+    ) throws AuthenticationException {
         try {
             // JSON 요청 바디 파싱
-            Map<String, String> requestMap = objectMapper.readValue(request.getInputStream(), Map.class);
+            Map<String, Object> requestMap = objectMapper.readValue(request.getInputStream(), new TypeReference<Map<String, Object>>() {});
 
-            String email = requestMap.get("email");
-            String userId = requestMap.get("userId");
-            String password = requestMap.get("password");
+            String email = requestMap.get("email") == null ? null : requestMap.get("email").toString();
+            String userId = requestMap.get("userId") == null ? null : requestMap.get("userId").toString();
+            String password = requestMap.get("password") == null ? "" : requestMap.get("password").toString();
+
+            // rememberMe 파싱
+            Object rememberMeRaw = requestMap.get("rememberMe");
+            boolean rememberMe = false;
+            if(rememberMeRaw instanceof Boolean b) rememberMe = b;
+            else if (rememberMeRaw instanceof String s) rememberMe = "true".equalsIgnoreCase(s);
+
+            // SuccessHandler로 rememberMe 정보 전달 (Authentication 객체에 담아서)
+            request.setAttribute("rememberMe", rememberMe);
 
             String principal = (email != null && !email.isBlank()) ? email : userId;
 

--- a/src/main/java/com/a404/duckonback/common/filter/JWTFilter.java
+++ b/src/main/java/com/a404/duckonback/common/filter/JWTFilter.java
@@ -49,7 +49,7 @@ public class JWTFilter extends OncePerRequestFilter {
             "/ws-chat/**"
     );
 
-    private static final List<String> BLACKLIST = List.of(
+    private static final List<String> FILTER_REQUIRED = List.of(
             "/api/auth/logout"
     );
 
@@ -84,7 +84,7 @@ public class JWTFilter extends OncePerRequestFilter {
     protected boolean shouldNotFilter(HttpServletRequest request) {
         if ("OPTIONS".equalsIgnoreCase(request.getMethod())) return true;
         String uri = request.getRequestURI();
-        if (matchesAny(uri, BLACKLIST)) return false;
+        if (matchesAny(uri, FILTER_REQUIRED)) return false;
         return matchesAny(uri, WHITELIST);
     }
 

--- a/src/main/java/com/a404/duckonback/common/handler/JsonAuthSuccessHandler.java
+++ b/src/main/java/com/a404/duckonback/common/handler/JsonAuthSuccessHandler.java
@@ -1,5 +1,6 @@
 package com.a404.duckonback.common.handler;
 
+import com.a404.duckonback.common.util.CookieUtil;
 import com.a404.duckonback.domain.auth.dto.LoginResponseDTO;
 import com.a404.duckonback.domain.user.dto.UserDTO;
 import com.a404.duckonback.domain.user.entity.User;
@@ -23,25 +24,45 @@ import java.time.Instant;
 @Component
 @RequiredArgsConstructor
 public class JsonAuthSuccessHandler implements AuthenticationSuccessHandler {
+
+    private static final String REFRESH_COOKIE_NAME = "refreshToken";
+    private static final String SAME_SITE = "Lax";
+
     private final ObjectMapper    objectMapper;
     private final JWTUtil         jwtUtil;
     private final ArtistService   artistService;
     private final AuthAuditService authAuditService;
 
     @Override
-    public void onAuthenticationSuccess(HttpServletRequest req,
-                                        HttpServletResponse res,
-                                        Authentication auth) throws IOException {
+    public void onAuthenticationSuccess(
+            HttpServletRequest req,
+            HttpServletResponse res,
+            Authentication auth
+    ) throws IOException {
+
         CustomUserPrincipal principal = (CustomUserPrincipal) auth.getPrincipal();
         User user = principal.getUser();
 
         Instant now = authAuditService.markLoggedIn(user.getId());
 
-        // 토큰 생성
+        // 1. 토큰 생성
         String access  = jwtUtil.generateAccessToken(user);
         String refresh = jwtUtil.generateRefreshToken(user);
 
-        // DTO 직접 빌드
+        // 2. refresh는 HTTP Only 쿠키로 전달
+        boolean secure = isHttps(req); // Prod(https) true, Dev, local(http) false
+        Integer maxAge = resolveRefreshCookieMaxAge(req); // rememberMe(자동로그인) 여부에 따라 세션/영구 쿠키 결정
+
+        CookieUtil.setHttpOnlyCookie(
+                res,
+                REFRESH_COOKIE_NAME,
+                refresh,
+                secure,
+                SAME_SITE,
+                maxAge
+        );
+
+        // 3. 응답 body에는 access 토큰과 유저 정보만 담아서 JSON으로 전달
         UserDTO userDTO = UserDTO.builder()
                 .email(user.getEmail())
                 .userId(user.getUserId())
@@ -56,14 +77,39 @@ public class JsonAuthSuccessHandler implements AuthenticationSuccessHandler {
 
         LoginResponseDTO body = LoginResponseDTO.builder()
                 .accessToken(access)
-                .refreshToken(refresh)
                 .user(userDTO)
                 .build();
 
-        // JSON 응답
+        // 4. JSON 응답
         res.setStatus(HttpStatus.OK.value());
         res.setContentType(MediaType.APPLICATION_JSON_VALUE);
         objectMapper.writeValue(res.getWriter(), body);
+    }
+
+    /**
+     * 현재 요청이 https인지 판단 (프록시 뒤면 X-Forwarded-Proto까지 확인)
+     */
+    private boolean isHttps(HttpServletRequest request) {
+        String forwardedProto = request.getHeader("X-Forwarded-Proto");
+        if (forwardedProto != null) {
+            return "https".equalsIgnoreCase(forwardedProto);
+        }
+        return request.isSecure();
+    }
+
+    /**
+     * 자동로그인(rememberMe) ON/OFF에 따라 refresh 쿠키 만료를 결정
+     * - ON  : persistent cookie (예: 14일)
+     * - OFF : session cookie (null)
+     */
+    private Integer resolveRefreshCookieMaxAge(HttpServletRequest request) {
+        Object v = request.getAttribute("rememberMe");
+        boolean rememberMe = (v instanceof Boolean b) && b;
+
+        if (rememberMe) {
+            return 14 * 24 * 60 * 60; // 14일
+        }
+        return null; // 세션 쿠키
     }
 }
 

--- a/src/main/java/com/a404/duckonback/common/response/SuccessCode.java
+++ b/src/main/java/com/a404/duckonback/common/response/SuccessCode.java
@@ -14,6 +14,8 @@ public enum SuccessCode {
     GET_USER_ROOM_CREATE_HISTORY_SUCCESS(200, HttpStatus.OK, "유저의 방 생성 기록을 성공적으로 불러왔습니다."),
     GET_USER_MEME_CREATE_HISTORY_SUCCESS(200, HttpStatus.OK, "유저의 밈 생성 기록을 성공적으로 불러왔습니다."),
     EMAIL_VERIFIED(200,HttpStatus.OK,"이메일 인증이 완료되었습니다."),
+    AUTH_REFRESH_SUCCESS(200, HttpStatus.OK, "인증 토큰이 성공적으로 갱신되었습니다."),
+    AUTH_LOGOUT_SUCCESS(200, HttpStatus.OK, "로그아웃이 성공적으로 처리되었습니다."),
 
     // 회원가입 관련
     USER_SIGNUP_SUCCESS(201, HttpStatus.CREATED, "회원가입이 완료되었습니다."),

--- a/src/main/java/com/a404/duckonback/common/util/CookieUtil.java
+++ b/src/main/java/com/a404/duckonback/common/util/CookieUtil.java
@@ -8,28 +8,45 @@ import java.util.Arrays;
 
 public class CookieUtil {
 
+    private CookieUtil(){}
+
     /**
      * HttpOnly 쿠키 추가
      */
-    public static void addHttpOnlyCookie(HttpServletResponse response, String name, String value, int maxAgeInSeconds) {
-        Cookie cookie = new Cookie(name, value);
-        cookie.setPath("/");
-        cookie.setHttpOnly(true);    // JavaScript에서 접근 불가
-        cookie.setSecure(true);      // HTTPS에서만 전송 (개발 환경에서는 false 가능)
-        cookie.setMaxAge(maxAgeInSeconds);
-        response.addCookie(cookie);
+    public static void setHttpOnlyCookie(
+            HttpServletResponse response,
+            String name,
+            String value,
+            boolean secure,
+            String sameSite,
+            Integer maxAgeSec
+    ) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(name).append("=").append(value).append("; Path=/; HttpOnly; ");
+
+        if(secure) sb.append("Secure; ");
+        if(sameSite!=null) sb.append("SameSite=").append(sameSite).append("; ");
+        if(maxAgeSec != null) sb.append("Max-Age=").append(maxAgeSec).append("; ");
+
+        response.addHeader("Set-Cookie", sb.toString());
     }
 
     /**
      * 쿠키 삭제 (같은 이름의 빈값 쿠키 추가)
      */
-    public static void deleteCookie(HttpServletResponse response, String name) {
-        Cookie cookie = new Cookie(name, "");
-        cookie.setPath("/");
-        cookie.setMaxAge(0);         // 0초 = 즉시 만료
-        cookie.setHttpOnly(true);
-        cookie.setSecure(true);
-        response.addCookie(cookie);
+    public static void deleteCookie(
+            HttpServletResponse response,
+            String name,
+            boolean secure,
+            String sameSite
+    ) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(name).append("=; Path=/; HttpOnly; Max-Age=0; ");
+
+        if(secure) sb.append("Secure; ");
+        if(sameSite!=null) sb.append("SameSite=").append(sameSite).append("; ");
+
+        response.addHeader("Set-Cookie", sb.toString());
     }
 
     /**

--- a/src/main/java/com/a404/duckonback/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/a404/duckonback/domain/auth/controller/AuthController.java
@@ -7,12 +7,15 @@ import com.a404.duckonback.common.notification.email.EmailVerificationService;
 import com.a404.duckonback.common.response.ApiResponseDTO;
 import com.a404.duckonback.common.response.ErrorCode;
 import com.a404.duckonback.common.response.SuccessCode;
+import com.a404.duckonback.domain.auth.dto.RefreshResponseDTO;
 import com.a404.duckonback.domain.auth.service.AuthService;
 import com.a404.duckonback.domain.auth.dto.LoginRequestDTO;
 import com.a404.duckonback.domain.auth.dto.SignupRequestDTO;
 import com.a404.duckonback.domain.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -73,21 +76,25 @@ public class AuthController {
         return ResponseEntity.ok().body(Map.of("isDuplicate", isDuplicate));
     }
 
-    @Operation(summary = "토큰 갱신 (JWT 필요O)", description = "리프레시 토큰을 사용하여 새로운 액세스 토큰, 리프레시 토큰을 발급받습니다.")
+    @Operation(summary = "토큰 갱신 (JWT 필요X)", description = "HttpOnly 쿠키의 refreshToken으로 access token을 재발급합니다.")
     @PostMapping("/refresh")
-    public ResponseEntity<?> refreshJWT(@RequestHeader("Authorization") String refreshTokenHeader) {
-        Map<String, String> tokenMap = authService.refreshJWT(refreshTokenHeader);
-        return ResponseEntity.ok(tokenMap);
+    public ResponseEntity<ApiResponseDTO<RefreshResponseDTO>> refreshJWT(
+            HttpServletRequest request,
+            HttpServletResponse response
+    ) {
+        RefreshResponseDTO dto = authService.refreshJWT(request, response);
+        return ResponseEntity.ok(ApiResponseDTO.success(SuccessCode.AUTH_REFRESH_SUCCESS, dto));
     }
 
-    @Operation(summary = "로그아웃 (JWT 필요O)", description = "사용자가 로그아웃합니다. 리프레시 토큰을 무효화합니다.")
+    @Operation(summary = "로그아웃 (JWT 필요O)", description = "access 블랙리스트 처리 + refreshToken 쿠키 삭제")
     @PostMapping("/logout")
-    public ResponseEntity<?> logout(
+    public ResponseEntity<ApiResponseDTO<Void>> logout(
             @AuthenticationPrincipal CustomUserPrincipal principal,
-            @RequestHeader(value = "X-Refresh-Token", required = false) String refreshToken
+            HttpServletRequest request,
+            HttpServletResponse response
     ) {
-        authService.logout(principal.getUser(), refreshToken);
-        return ResponseEntity.ok(Map.of("message", "로그아웃 완료"));
+        authService.logout(principal.getUser(), request, response);
+        return ResponseEntity.ok(ApiResponseDTO.success(SuccessCode.AUTH_LOGOUT_SUCCESS));
     }
 
     @Operation(summary = "이메일 인증번호 발송 (JWT 필요X)", description = "싸피 와이파이로 작동하지 않습니다. 꼭 핫스팟으로 실행해주세요!")

--- a/src/main/java/com/a404/duckonback/domain/auth/dto/LoginResponseDTO.java
+++ b/src/main/java/com/a404/duckonback/domain/auth/dto/LoginResponseDTO.java
@@ -11,7 +11,6 @@ import lombok.*;
 public class LoginResponseDTO {
 
     private String accessToken;
-    private String refreshToken;
     private UserDTO user;
 
 

--- a/src/main/java/com/a404/duckonback/domain/auth/dto/RefreshResponseDTO.java
+++ b/src/main/java/com/a404/duckonback/domain/auth/dto/RefreshResponseDTO.java
@@ -1,0 +1,10 @@
+package com.a404.duckonback.domain.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class RefreshResponseDTO {
+    private String accessToken;
+}

--- a/src/main/java/com/a404/duckonback/domain/auth/service/AuthService.java
+++ b/src/main/java/com/a404/duckonback/domain/auth/service/AuthService.java
@@ -3,17 +3,18 @@ package com.a404.duckonback.domain.auth.service;
 import com.a404.duckonback.common.dto.JWTDTO;
 import com.a404.duckonback.domain.auth.dto.LoginRequestDTO;
 import com.a404.duckonback.domain.auth.dto.LoginResponseDTO;
+import com.a404.duckonback.domain.auth.dto.RefreshResponseDTO;
 import com.a404.duckonback.domain.auth.dto.SignupRequestDTO;
 import com.a404.duckonback.domain.user.entity.User;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.ResponseEntity;
-
-import java.util.Map;
 
 public interface AuthService {
     LoginResponseDTO login(LoginRequestDTO loginRequest);
     ResponseEntity<?> signup(SignupRequestDTO dto);
-    void logout(User user, String refreshTokenHeader);
-    Map<String, String> refreshJWT(String refreshHeader);
+    void logout(User user, HttpServletRequest request, HttpServletResponse response);
+    RefreshResponseDTO refreshJWT(HttpServletRequest request, HttpServletResponse response);
     JWTDTO getJWT(String email);
 
 }

--- a/src/main/java/com/a404/duckonback/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/a404/duckonback/domain/auth/service/AuthServiceImpl.java
@@ -1,10 +1,14 @@
 package com.a404.duckonback.domain.auth.service;
 
 import com.a404.duckonback.common.dto.JWTDTO;
+import com.a404.duckonback.common.enums.TokenStatus;
+import com.a404.duckonback.common.response.ErrorCode;
+import com.a404.duckonback.common.util.CookieUtil;
 import com.a404.duckonback.domain.artist.artist.service.ArtistFollowService;
 import com.a404.duckonback.domain.artist.artist.service.ArtistService;
 import com.a404.duckonback.domain.auth.dto.LoginRequestDTO;
 import com.a404.duckonback.domain.auth.dto.LoginResponseDTO;
+import com.a404.duckonback.domain.auth.dto.RefreshResponseDTO;
 import com.a404.duckonback.domain.auth.dto.SignupRequestDTO;
 import com.a404.duckonback.domain.user.dto.UserDTO;
 import com.a404.duckonback.domain.user.entity.User;
@@ -17,20 +21,18 @@ import com.a404.duckonback.common.security.token.TokenBlacklistService;
 import com.a404.duckonback.domain.user.service.UserService;
 import com.a404.duckonback.common.util.JWTUtil;
 import io.jsonwebtoken.Claims;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
 import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -124,7 +126,6 @@ public class AuthServiceImpl implements AuthService {
 
         return LoginResponseDTO.builder()
                 .accessToken(accessToken)
-                .refreshToken(refreshToken)
                 .user(userDTO)
                 .build();
     }
@@ -158,59 +159,71 @@ public class AuthServiceImpl implements AuthService {
     }
 
     @Override
-    public Map<String, String> refreshJWT(String refreshHeader){
+    public RefreshResponseDTO refreshJWT(HttpServletRequest request, HttpServletResponse response) {
         final long now = System.currentTimeMillis();
 
-        String refreshToken = jWTUtil.requireValidToken(refreshHeader);
-        String userId = null;
-
-        if (refreshToken != null) {
-            Claims claims = jWTUtil.getClaims(refreshToken);
-            userId = claims.getSubject();
-
-            Date exp = claims.getExpiration();
-            long ttl = exp.getTime() - now;
-            if (ttl > 0) tokenBlacklistService.blacklist(refreshToken, ttl);
+        String refreshToken = CookieUtil.getCookieValue(request, "refreshToken");
+        if(refreshToken == null || refreshToken.isBlank()) {
+            throw new CustomException(ErrorCode.USER_NOT_AUTHENTICATED);
         }
 
-        User user = userService.findByUserId(userId);
+        TokenStatus status = jWTUtil.getTokenValidationStatus(refreshToken);
+        boolean revoked = tokenBlacklistService.isBlacklisted(refreshToken);
 
+        if(status != TokenStatus.VALID || revoked){
+            CookieUtil.deleteCookie(response, "refreshToken", isHttps(request), "Lax");
+            throw new CustomException(ErrorCode.USER_NOT_AUTHENTICATED);
+        }
+
+        Claims claims = jWTUtil.getClaims(refreshToken);
+        String userId = claims.getSubject();
+
+        long ttl = claims.getExpiration().getTime() - now;
+        if (ttl > 0) tokenBlacklistService.blacklist(refreshToken, ttl);
+
+        User user = userService.findActiveByUserId(userId);
+
+        String newAccessToken  = jWTUtil.generateAccessToken(user);
         String newRefreshToken = jWTUtil.generateRefreshToken(user);
-        String newAccessToken = jWTUtil.generateAccessToken(user);
 
-        Map<String, String> result = new HashMap<>();
-        result.put("accessToken", newAccessToken);
-        result.put("refreshToken", newRefreshToken);
+        CookieUtil.setHttpOnlyCookie(response, "refreshToken", newRefreshToken, isHttps(request), "Lax", null);
 
-        return result;
+        return new RefreshResponseDTO(newAccessToken);
     }
 
 
     @Override
     @Transactional
-    public void logout(User user, String refreshHeader) {
+    public void logout(User user, HttpServletRequest request, HttpServletResponse response) {
         final long now = System.currentTimeMillis();
 
-        // Access Token (Authorization)
-        ServletRequestAttributes attrs =
-                (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
-        if (attrs != null) {
-            String authorization = attrs.getRequest().getHeader("Authorization");
-            String accessToken = jWTUtil.normalizeIfValid(authorization);
-            if (accessToken != null) {
-                Date exp = jWTUtil.getClaims(accessToken).getExpiration();
-                long ttl = exp.getTime() - now;
-                if (ttl > 0) tokenBlacklistService.blacklist(accessToken, ttl);
-            }
+        // access 블랙리스트
+        String authorization = request.getHeader("Authorization");
+        String accessToken = jWTUtil.normalizeIfValid(authorization);
+
+        if(accessToken != null && !accessToken.isEmpty()) {
+            Date expiration = jWTUtil.getClaims(accessToken).getExpiration();
+            long ttl = expiration.getTime() - now;
+            if (ttl > 0) tokenBlacklistService.blacklist(accessToken, ttl);
         }
 
-        // Refresh Token (X-Refresh-Token) - Bearer 유무와 무관
-        String refreshToken = jWTUtil.normalizeIfValid(refreshHeader);
-        if (refreshToken != null) {
-            Date exp = jWTUtil.getClaims(refreshToken).getExpiration();
-            long ttl = exp.getTime() - now;
+        // refresh 쿠키 삭제
+        String refreshToken = CookieUtil.getCookieValue(request, "refreshToken");
+        if(refreshToken != null && !refreshToken.isBlank()
+            && jWTUtil.getTokenValidationStatus(refreshToken).equals(TokenStatus.VALID)) {
+            Date expiration = jWTUtil.getClaims(refreshToken).getExpiration();
+            long ttl = expiration.getTime() - now;
             if (ttl > 0) tokenBlacklistService.blacklist(refreshToken, ttl);
         }
+
+        // 쿠키 삭제
+        CookieUtil.deleteCookie(response, "refreshToken", isHttps(request), "Lax");
+    }
+
+    private boolean isHttps(HttpServletRequest request) {
+        String forwardedProto = request.getHeader("X-Forwarded-Proto");
+        if (forwardedProto != null) return "https".equalsIgnoreCase(forwardedProto);
+        return request.isSecure();
     }
 
 }


### PR DESCRIPTION
## 🐬 요약

JWT 인증 구조를 개선하여 **Refresh Token을 HttpOnly Cookie 기반으로 전환**하고,
`rememberMe` 기반 자동로그인 기능을 추가했습니다.

* refreshToken을 JSON 응답에서 제거하고 HttpOnly 쿠키로 발급
* refresh API를 헤더 기반 → 쿠키 기반 구조로 변경
* refresh rotation + 블랙리스트 유지
* logout 시 access/refresh 모두 무효화 및 쿠키 삭제
* 자동로그인(14일 유지) 지원

보안성을 강화하면서 기존 인증 아키텍처를 유지하는 방향으로 리팩토링했습니다.

---

## 👻 유형

* [x] 기능 개발 (Feature)
* [ ] UI / 디자인 개선
* [x] 버그 수정
* [ ] 문서 변경
* [ ] Infra / CICD

---

## 🍀 작업 내용

### 1️⃣ Refresh Token 저장 전략 변경

#### 변경 전

* accessToken + refreshToken을 JSON body로 응답
* 프론트에서 refreshToken을 localStorage에 저장
* refresh 요청 시 Authorization 헤더로 전달

#### 변경 후

* accessToken만 JSON body로 응답
* refreshToken은 **HttpOnly Cookie**로 발급
* JS에서 refreshToken 접근 불가
* refresh 요청 시 쿠키 자동 전송

---

### 2️⃣ rememberMe(자동로그인) 기능 추가

* 로그인 요청 JSON에 `rememberMe` 필드 추가
* `CustomJsonUsernamePasswordAuthenticationFilter`에서 JSON 직접 파싱
* SuccessHandler로 attribute 전달
* rememberMe=true → 14일 유지 쿠키 발급
* rememberMe=false → 세션 쿠키 발급

---

### 3️⃣ Refresh API 구조 변경

* `@RequestHeader` 제거
* `HttpServletRequest`에서 쿠키로 refreshToken 조회
* 유효성 검사 + 블랙리스트 검사
* refresh rotation 유지 (기존 refresh 블랙리스트 → 새 refresh 발급)

---

### 4️⃣ Logout 로직 개선

* accessToken 블랙리스트 처리
* refreshToken 블랙리스트 처리
* HttpOnly 쿠키 삭제(Set-Cookie Max-Age=0)

---

### 5️⃣ JWTFilter 구조 점검

* `/api/auth/**`는 필터 스킵
* `/api/auth/logout`만 예외적으로 필터 적용
* guest 허용 경로 유지
* whitelist / blacklist 순서 점검 완료

---

### 6️⃣ 버그 수정

#### ❌ 기존 코드

```java
if(accessToken == null || !accessToken.isBlank())
```

→ OR 조건으로 NullPointer 위험

#### ✅ 수정

```java
if(accessToken != null && !accessToken.isBlank())
```

---

## ✅ 테스트 방법

### 1️⃣ 로그인 테스트

```json
{
  "userId": "...",
  "password": "...",
  "rememberMe": true
}
```

* 응답 body: accessToken 정상 수신
* Response Header:

  ```
  Set-Cookie: refreshToken=...; HttpOnly; SameSite=Lax; Max-Age=1209600;
  ```
* DevTools → Application → Cookies에서 refreshToken 확인

---

### 2️⃣ refresh API 테스트

* `/api/auth/refresh` 호출
* Authorization 헤더 없이 호출
* 쿠키 기반 refresh 정상 동작 확인
* 새 refreshToken 쿠키 발급 확인

---

### 3️⃣ logout 테스트

* `/api/auth/logout` 호출
* 응답 헤더:

  ```
  Set-Cookie: refreshToken=; Max-Age=0;
  ```
* 쿠키 삭제 확인
* 이후 refresh 호출 시 401 확인

---

### 4️⃣ 401 → refresh → 재시도 플로우 확인

* accessToken 만료 시
* refresh 정상 동작
* 새 accessToken 발급 확인

---

## 🧭 향후 작업 계획

* [ ] refresh 동시 요청(single-flight) 처리 고려
* [ ] CSRF 방어 전략 정교화 (SameSite=None + Secure 환경 대응)
* [ ] refresh 만료 시 UX 개선 (자동 로그아웃 UX)

---

## 🙌 리뷰 포인트

* [ ] HttpOnly Cookie 기반 refresh 구조가 현재 보안 정책에 적합한지
* [ ] refresh rotation + 블랙리스트 TTL 계산 로직 검토
* [ ] 필터 whitelist / blacklist 순서가 명확한지
* [ ] rememberMe 쿠키 만료 전략 적절성 검토
