### PR TITLE
[Feat] Api 공통 Response 상세 처리 및 유저 닉네임 길이 제한

### DIFF
--- a/src/main/java/com/a404/duckonback/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/a404/duckonback/common/exception/GlobalExceptionHandler.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.BindException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import com.a404.duckonback.common.response.ApiResponseDTO;
@@ -12,36 +14,53 @@ import org.apache.tomcat.util.http.fileupload.impl.FileCountLimitExceededExcepti
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import org.springframework.web.multipart.MultipartException;
 
-import java.util.HashMap;
-import java.util.Map;
-
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(CustomException.class)
-    public ResponseEntity<Map<String, Object>> handleCustomException(CustomException ex) {
-        Map<String, Object> body = new HashMap<>();
-        body.put("message", ex.getMessage());
-        body.put("status", ex.getStatus().value());
+    public ResponseEntity<ApiResponseDTO<Object>> handleCustomException(CustomException ex) {
+        ErrorCode code = ex.getErrorCode();
 
-        // 추가 데이터가 있다면 포함
-        if (ex.getData() != null && !ex.getData().isEmpty()) {
-            body.putAll(ex.getData());
+        // ErrorCode가 명확히 매핑되는 경우
+        if(code != null){
+            return ResponseEntity
+                    .status(code.getHttpStatus())
+                    .body(ApiResponseDTO.fail(code));
         }
 
-        return ResponseEntity.status(ex.getStatus()).body(body);
+        // ErrorCode가 없는 경우, 기본적으로 INVALID_REQUEST로 처리
+        return ResponseEntity
+                .status(ex.getStatus())
+                .body(ApiResponseDTO.fail(ErrorCode.INVALID_REQUEST, ex.getMessage()));
     }
 
-    @ExceptionHandler(Exception.class)
-    public ResponseEntity<Map<String, Object>> handleGenericException(Exception ex) {
-        ex.printStackTrace(); // 개발 중 예외 확인용 로그
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponseDTO<Object>> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex) {
+        String message = ex.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .findFirst()
+                .map(fieldError -> fieldError.getDefaultMessage())
+                .orElse("잘못된 요청입니다.");
 
-        Map<String, Object> body = new HashMap<>();
-        body.put("message", "서버 내부 오류가 발생했습니다.");
-        body.put("status", 500);
+        return ResponseEntity
+                .status(ErrorCode.INVALID_REQUEST.getHttpStatus())
+                .body(ApiResponseDTO.fail(ErrorCode.INVALID_REQUEST, message));
+    }
 
-        return ResponseEntity.status(500).body(body);
+    @ExceptionHandler(BindException.class)
+    public ResponseEntity<ApiResponseDTO<Object>> handleBindException(BindException ex) {
+        String message = ex.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .findFirst()
+                .map(fieldError -> fieldError.getDefaultMessage())
+                .orElse("잘못된 요청입니다.");
+
+        return ResponseEntity
+                .status(ErrorCode.INVALID_REQUEST.getHttpStatus())
+                .body(ApiResponseDTO.fail(ErrorCode.INVALID_REQUEST, message));
     }
 
     // 파일 용량 초과 (Spring이 던짐)
@@ -104,6 +123,15 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(ErrorCode.INVALID_REQUEST.getHttpStatus())
                 .body(ApiResponseDTO.fail(ErrorCode.INVALID_REQUEST));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponseDTO<Object>> handleGenericException(Exception ex) {
+        log.error("[GlobalExceptionHandler] Unhandled exception: {}", ex.getMessage(), ex);
+
+        return ResponseEntity
+                .status(ErrorCode.INTERNAL_SERVER_ERROR.getHttpStatus())
+                .body(ApiResponseDTO.fail(ErrorCode.INTERNAL_SERVER_ERROR));
     }
 
     private Throwable getRootCause(Throwable t) {

--- a/src/main/java/com/a404/duckonback/common/response/ApiResponseDTO.java
+++ b/src/main/java/com/a404/duckonback/common/response/ApiResponseDTO.java
@@ -63,7 +63,7 @@ public record ApiResponseDTO<T>(
 
     /*
      * @Valid 오류 메시지 전달 메서드*/
-    public static ApiResponseDTO<?> fail(ErrorCode errorCode, String customMessage) {
+    public static ApiResponseDTO<Object> fail(final ErrorCode errorCode, final String customMessage) {
         return ApiResponseDTO.builder()
                 .httpStatus(errorCode.getHttpStatus())
                 .status(errorCode.getCode())

--- a/src/main/java/com/a404/duckonback/domain/me/controller/MeController.java
+++ b/src/main/java/com/a404/duckonback/domain/me/controller/MeController.java
@@ -58,7 +58,7 @@ public class MeController {
     @PatchMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<?> updateMyInfo(
             @AuthenticationPrincipal CustomUserPrincipal principal,
-            @ModelAttribute UpdateProfileRequestDTO newUserInfo
+            @Valid @ModelAttribute UpdateProfileRequestDTO newUserInfo
     ) {
         userService.updateUserInfo(principal.getUser().getUserId(), newUserInfo);
         return ResponseEntity.ok(Map.of("message", "회원 정보가 수정되었습니다."));

--- a/src/main/java/com/a404/duckonback/domain/me/dto/UpdateProfileRequestDTO.java
+++ b/src/main/java/com/a404/duckonback/domain/me/dto/UpdateProfileRequestDTO.java
@@ -1,5 +1,6 @@
 package com.a404.duckonback.domain.me.dto;
 
+import jakarta.validation.constraints.Size;
 import lombok.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -9,7 +10,9 @@ import org.springframework.web.multipart.MultipartFile;
 @AllArgsConstructor
 @Builder
 public class UpdateProfileRequestDTO {
+    @Size(min = 1, max = 15, message = "닉네임은 1~15자 사이여야 합니다.")
     private String nickname;
+
     private String language;
     private MultipartFile profileImg;
 }

--- a/src/main/java/com/a404/duckonback/domain/user/entity/User.java
+++ b/src/main/java/com/a404/duckonback/domain/user/entity/User.java
@@ -9,6 +9,7 @@ import com.a404.duckonback.domain.room.entity.Room;
 import com.a404.duckonback.common.enums.SocialProvider;
 import com.a404.duckonback.common.enums.UserRole;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.Size;
 import lombok.*;
 
 import java.time.Instant;
@@ -45,7 +46,8 @@ public class User {
     @Column(name = "password", nullable = false, length = 255)
     private String password; // OAuth 계정은 더미/랜덤 해시 보관
 
-    @Column(name = "nickname", nullable = false, length = 100)
+    @Size(min = 1, max = 15)
+    @Column(name = "nickname", nullable = false, length = 20)
     private String nickname;
 
     @Column(name = "provider", length = 20)


### PR DESCRIPTION
## 🐬 요약

---

DTO Validation 실패 시 500 에러가 발생하던 문제를 해결하고,
Validation 오류 메시지를 프론트에 전달할 수 있도록 전역 예외 처리 로직을 개선했습니다.

주요 변경 사항

* `@Valid` 기반 DTO validation 적용
* `MethodArgumentNotValidException` / `BindException` 전역 처리 추가
* DTO에 정의된 validation 메시지를 프론트 응답으로 전달
* `ApiResponseDTO.fail(ErrorCode, message)` 반환 타입 수정
* Validation 오류 발생 시 500 → 400 응답으로 정상 처리

---

## 👻 유형

* [ ] 기능 개발 (Feature)
* [ ] UI / 디자인 개선
* [x] 버그 수정
* [ ] 문서 변경
* [ ] Infra / CICD

---

## 🍀 작업 내용

### 1️⃣ DTO Validation 적용

프로필 수정 요청 DTO에 validation을 적용하여 입력값 검증을 Controller 레벨에서 처리하도록 변경했습니다.

```java
public class UpdateProfileRequestDTO {

    @Size(min = 1, max = 15, message = "닉네임은 1~15자 사이여야 합니다.")
    private String nickname;

    private String language;

    private MultipartFile profileImg;
}
```

Controller에서는 `@Valid`를 통해 자동 검증이 수행됩니다.

```java
@PatchMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
public ResponseEntity<?> updateMyInfo(
        @AuthenticationPrincipal CustomUserPrincipal principal,
        @Valid @ModelAttribute UpdateProfileRequestDTO newUserInfo
) {
    userService.updateUserInfo(principal.getUser().getUserId(), newUserInfo);
    return ResponseEntity.ok(Map.of("message", "회원 정보가 수정되었습니다."));
}
```

---

### 2️⃣ Validation 예외 전역 처리 추가

DTO validation 실패 시 발생하는 예외를 전역에서 처리하도록 `GlobalExceptionHandler`에 핸들러를 추가했습니다.

처리 대상 예외

* `MethodArgumentNotValidException`
* `BindException`

```java
@ExceptionHandler(MethodArgumentNotValidException.class)
public ResponseEntity<ApiResponseDTO<Object>> handleMethodArgumentNotValidException(
        MethodArgumentNotValidException ex
) {
    String message = ex.getBindingResult()
            .getFieldErrors()
            .stream()
            .findFirst()
            .map(fieldError -> fieldError.getDefaultMessage())
            .orElse("유효하지 않은 요청입니다.");

    return ResponseEntity
            .status(ErrorCode.INVALID_REQUEST.getHttpStatus())
            .body(ApiResponseDTO.fail(ErrorCode.INVALID_REQUEST, message));
}
```

이를 통해 DTO에 정의된 validation 메시지가 그대로 응답에 전달됩니다.

---

### 3️⃣ ApiResponseDTO 타입 수정

기존 코드에서는 아래 메서드가

```java
public static ApiResponseDTO<?> fail(ErrorCode errorCode, String customMessage)
```

와일드카드 타입(`<?>`)을 사용하여 `ResponseEntity<ApiResponseDTO<Object>>`와 타입 충돌이 발생했습니다.

이를 해결하기 위해 반환 타입을 명확히 수정했습니다.

```java
public static ApiResponseDTO<Object> fail(ErrorCode errorCode, String customMessage) {
    return ApiResponseDTO.<Object>builder()
            .httpStatus(errorCode.getHttpStatus())
            .status(errorCode.getCode())
            .message(customMessage)
            .data(null)
            .build();
}
```

---

### 4️⃣ Validation 오류 응답 구조 개선

기존 응답

```json
{
  "status": 500,
  "message": "서버 내부 오류가 발생했습니다."
}
```

개선 후

```json
{
  "status": 400,
  "message": "닉네임은 1~15자 사이여야 합니다.",
  "data": null
}
```

이를 통해 프론트에서 사용자에게 정확한 validation 메시지를 표시할 수 있습니다.

---

## ✅ 테스트 방법

### 1️⃣ 닉네임 길이 초과 요청

요청

```
PATCH /api/me
Content-Type: multipart/form-data
nickname = 16자 이상
```

응답

```json
{
  "status": 400,
  "message": "닉네임은 1~15자 사이여야 합니다."
}
```

### 2️⃣ 정상 요청

```
nickname = "duckon"
```

응답

```
200 OK
회원 정보가 수정되었습니다.
```

---

## 🧭 향후 작업 계획

* [ ] validation error code 세분화 (`INVALID_INPUT_VALUE` 등)
* [ ] validation 오류 필드 목록 반환 구조 확장
* [ ] 공통 validation 메시지 관리 (message source)

---

## 🙌 리뷰 포인트

* [ ] GlobalExceptionHandler에서 validation 예외 처리 방식이 적절한지
* [ ] ApiResponseDTO 제네릭 타입 변경 영향 범위 확인
* [ ] DTO validation 정책 (닉네임 1~15자) 적절성 검토

