### PR TITLE
feat: 관리자 - 패널티 리스트 및 상세 내역 조회

### DIFF
--- a/src/main/java/com/a404/duckonback/common/response/ErrorCode.java
+++ b/src/main/java/com/a404/duckonback/common/response/ErrorCode.java
@@ -65,6 +65,7 @@ public enum ErrorCode {
     EMERGING_ARTIST_FOLLOW_NOT_FOUND(404,HttpStatus.NOT_FOUND,"라이징 아티스트를 팔로우하고있지 않습니다."),
     REPORT_NOT_FOUND(404,HttpStatus.NOT_FOUND,"존재하지 않는 신고입니다."),
     NOTIFICATION_SOURCE_NOT_FOUND(404,HttpStatus.NOT_FOUND,"알림의 소스가 존재하지 않습니다."),
+    PENALTY_NOT_FOUND(404,HttpStatus.NOT_FOUND,"존재하지 않는 제재입니다."),
 
     //409 CONFLICT
     DUPLICATE_ARTIST(409, HttpStatus.CONFLICT, "이미 존재하는 아티스트입니다."),

--- a/src/main/java/com/a404/duckonback/common/response/SuccessCode.java
+++ b/src/main/java/com/a404/duckonback/common/response/SuccessCode.java
@@ -37,6 +37,8 @@ public enum SuccessCode {
     ADMIN_REVIEW_ARTIST_CHANGE_REQUEST_SUCCESS(200, HttpStatus.OK, "[관리자] 아티스트 변경 요청 검토에 성공했습니다."),
     ADMIN_PATCH_EMERGING_ARTIST_SUCCESS(200, HttpStatus.OK, "[관리자] 라이징 아티스트 정보 수정에 성공했습니다."),
     ADMIN_UPDATE_HOME_SEARCH_PLACEHOLDER_SUCCESS(200, HttpStatus.OK, "[관리자] 홈 검색창 플레이스홀더 업데이트에 성공했습니다."),
+    ADMIN_GET_PENALTY_LIST_SUCCESS(200, HttpStatus.OK, "[관리자] 제재 목록 조회에 성공했습니다."),
+    ADMIN_GET_PENALTY_DETAIL_SUCCESS(200, HttpStatus.OK, "[관리자] 제재 상세 조회에 성공했습니다."),
 
     // 신고 api 관련
     REPORT_CREATE_SUCCESS(200, HttpStatus.OK, "신고가 성공적으로 저장되었습니다."),

--- a/src/main/java/com/a404/duckonback/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/a404/duckonback/domain/admin/controller/AdminController.java
@@ -20,6 +20,8 @@ import com.a404.duckonback.domain.admin.dto.ReportSearchConditionDTO;
 import com.a404.duckonback.domain.report.service.ReportService;
 import com.a404.duckonback.domain.user.service.EngagementBatchService;
 import com.a404.duckonback.common.filter.CustomUserPrincipal;
+import com.a404.duckonback.domain.admin.dto.AdminPenaltyListDTO;
+import com.a404.duckonback.domain.penalty.service.PenaltyService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -208,6 +210,23 @@ public class AdminController {
     ) {
         HomeSearchPlaceholderResponseDTO response = homeSearchPlaceholderService.updatePlaceholders(request.getItems(), principal.getId());
         return ResponseEntity.ok(ApiResponseDTO.success(SuccessCode.ADMIN_UPDATE_HOME_SEARCH_PLACEHOLDER_SUCCESS, response));
+    }
+
+    @Operation(summary = "제재 목록 조회 (JWT 필요O)", description = "제재 목록을 조회합니다.")
+    @GetMapping("/penalties")
+    public ResponseEntity<ApiResponseDTO<PageResponse<AdminPenaltyListDTO>>> getPenaltyList(
+        @RequestParam(defaultValue = "1") int page,
+        @RequestParam(defaultValue = "20") int size
+    ) {
+        PageResponse<AdminPenaltyListDTO> penaltyDTOs = adminService.getPenaltyList(page, size);
+        return ResponseEntity.ok(ApiResponseDTO.success(SuccessCode.ADMIN_GET_PENALTY_LIST_SUCCESS, penaltyDTOs));
+    }
+
+    @Operation(summary = "제재 상세 조회 (JWT 필요O)", description = "제재 상세를 조회합니다.")
+    @GetMapping("/penalties/{penaltyId}")
+    public ResponseEntity<ApiResponseDTO<AdminPenaltyDetailDTO>> getPenaltyDetail(@PathVariable Long penaltyId) {
+        AdminPenaltyDetailDTO penaltyDetail = adminService.getPenaltyDetail(penaltyId);
+        return ResponseEntity.ok(ApiResponseDTO.success(SuccessCode.ADMIN_GET_PENALTY_DETAIL_SUCCESS, penaltyDetail));
     }
 
 }

--- a/src/main/java/com/a404/duckonback/domain/admin/dto/AdminPenaltyDetailDTO.java
+++ b/src/main/java/com/a404/duckonback/domain/admin/dto/AdminPenaltyDetailDTO.java
@@ -1,0 +1,50 @@
+package com.a404.duckonback.domain.admin.dto;
+
+import com.a404.duckonback.common.enums.PenaltyType;
+import com.a404.duckonback.common.enums.PenaltyStatus;
+import com.a404.duckonback.domain.penalty.entity.Penalty;
+import com.a404.duckonback.domain.user.entity.User;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AdminPenaltyDetailDTO {
+    private Long penaltyId;
+    private Long userId;
+    private String nickname;
+    private String reason;
+    private PenaltyType penaltyType;
+    private PenaltyStatus status;
+    private LocalDateTime startAt;
+    private LocalDateTime endAt;
+    
+    private String userLoginId;
+    private String email;
+    private int previousPenaltyCount;
+    private int totalReportedCount;
+
+    public static AdminPenaltyDetailDTO fromEntity(Penalty penalty, User user) {
+        return AdminPenaltyDetailDTO.builder()
+            .penaltyId(penalty.getPenaltyId())
+            .userId(penalty.getUser().getId())
+            .nickname(penalty.getUser().getNickname())
+            .reason(penalty.getReason())
+            .penaltyType(penalty.getPenaltyType())
+            .status(penalty.getStatus())
+            .startAt(penalty.getStartAt())
+            .endAt(penalty.getEndAt())
+            .userLoginId(user.getUserId())
+            .email(user.getEmail())
+            .previousPenaltyCount(user.getPenalties().size())
+            .totalReportedCount(user.getReportsAsReported().size())
+            .build();
+    }
+}

--- a/src/main/java/com/a404/duckonback/domain/admin/dto/AdminPenaltyListDTO.java
+++ b/src/main/java/com/a404/duckonback/domain/admin/dto/AdminPenaltyListDTO.java
@@ -1,0 +1,27 @@
+package com.a404.duckonback.domain.admin.dto;
+
+import com.a404.duckonback.common.enums.PenaltyType;
+import com.a404.duckonback.common.enums.PenaltyStatus;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AdminPenaltyListDTO {
+
+    private Long penaltyId;
+    private Long userId;
+    private String nickname;
+    private String reason;
+    private PenaltyType penaltyType;
+    private PenaltyStatus status;
+    private LocalDateTime startAt;
+    private LocalDateTime endAt;
+}

--- a/src/main/java/com/a404/duckonback/domain/admin/service/AdminService.java
+++ b/src/main/java/com/a404/duckonback/domain/admin/service/AdminService.java
@@ -5,10 +5,14 @@ import com.a404.duckonback.domain.admin.dto.AdminUserListDTO;
 import com.a404.duckonback.domain.admin.dto.AdminArtistListDTO;
 import com.a404.duckonback.domain.admin.dto.AdminUserDetailDTO;
 import com.a404.duckonback.domain.admin.dto.UserSearchConditionDTO;
+import com.a404.duckonback.domain.admin.dto.AdminPenaltyListDTO;
+import com.a404.duckonback.domain.admin.dto.AdminPenaltyDetailDTO;
 
 public interface AdminService {
     PageResponse<AdminUserListDTO> getAdminUserList(int page, int size);
     PageResponse<AdminArtistListDTO> getAllArtists(int page, int size);
     AdminUserDetailDTO getUserDetail(String userId);
     PageResponse<AdminUserListDTO> searchAdminUserList(UserSearchConditionDTO condition, int page, int size);
+    PageResponse<AdminPenaltyListDTO> getPenaltyList(int page, int size);
+    AdminPenaltyDetailDTO getPenaltyDetail(Long penaltyId);
 }

--- a/src/main/java/com/a404/duckonback/domain/admin/service/AdminServiceImpl.java
+++ b/src/main/java/com/a404/duckonback/domain/admin/service/AdminServiceImpl.java
@@ -17,6 +17,8 @@ import com.a404.duckonback.domain.report.repository.ReportRepository;
 import com.a404.duckonback.domain.user.entity.User;
 import com.a404.duckonback.domain.user.repository.UserRepository;
 import com.a404.duckonback.common.response.ErrorCode;
+import com.a404.duckonback.domain.admin.dto.AdminPenaltyListDTO;
+import com.a404.duckonback.domain.admin.dto.AdminPenaltyDetailDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -101,5 +103,23 @@ public class AdminServiceImpl implements AdminService {
             condition.getRole(), 
             pageable);
         return PageResponse.from1Base(pageResult);
+    }
+
+    @Override
+    public PageResponse<AdminPenaltyListDTO> getPenaltyList(int page, int size) {
+        int safePage = Math.max(page - 1, 0);
+        int safeSize = Math.min(Math.max(size, 1), 100);
+        Pageable pageable = PageRequest.of(safePage, safeSize);
+        Page<AdminPenaltyListDTO> pageResult = penaltyRepository.findAllBy(pageable);
+        return PageResponse.from1Base(pageResult);
+    }
+
+    @Override
+    public AdminPenaltyDetailDTO getPenaltyDetail(Long penaltyId) {
+        Penalty penalty = penaltyRepository.findById(penaltyId)
+                .orElseThrow(() -> new CustomException(ErrorCode.PENALTY_NOT_FOUND));
+        User user = userRepository.findById(penalty.getUser().getId())
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        return AdminPenaltyDetailDTO.fromEntity(penalty, user);
     }
 }

--- a/src/main/java/com/a404/duckonback/domain/penalty/repository/PenaltyRepository.java
+++ b/src/main/java/com/a404/duckonback/domain/penalty/repository/PenaltyRepository.java
@@ -12,6 +12,9 @@ import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import com.a404.duckonback.domain.admin.dto.AdminPenaltyListDTO;
 
 @Repository
 public interface PenaltyRepository extends JpaRepository<Penalty, Long> {
@@ -32,5 +35,13 @@ public interface PenaltyRepository extends JpaRepository<Penalty, Long> {
     void expireOldPenalties(
             @Param("userId") Long userId,
             @Param("now") LocalDateTime now);
+
+    @Query("""
+      SELECT new com.a404.duckonback.domain.admin.dto.AdminPenaltyListDTO
+        (p.penaltyId, p.user.id, u.nickname, p.reason, p.penaltyType, p.status, p.startAt, p.endAt) 
+      FROM Penalty p
+      JOIN p.user u
+      """)
+    Page<AdminPenaltyListDTO> findAllBy(Pageable pageable);
 
 }


### PR DESCRIPTION
## Summary
- 관리자 페이지에서 제재(Penalty) 목록 조회 및 상세 조회 API 구현

## Changes

### 1. 제재 목록 조회 API
- **Endpoint:** `GET /admin/penalties?page=1&size=20`
- **Response:** 페이징된 제재 목록 (penaltyId, userId, nickname, reason, penaltyType, status, startAt, endAt)

### 2. 제재 상세 조회 API
- **Endpoint:** `GET /admin/penalties/{penaltyId}`
- **Response:** 제재 상세 정보 + 사용자 추가 정보 (userLoginId, email, previousPenaltyCount, totalReportedCount)

## Files Changed
- `AdminController.java` - 엔드포인트 추가
- `AdminService.java` - 인터페이스 메서드 선언
- `AdminServiceImpl.java` - 서비스 구현
- `AdminPenaltyListDTO.java` - nickname 필드 추가
- `AdminPenaltyDetailDTO.java` - 상세 조회용 DTO 생성
- `PenaltyRepository.java` - findAllBy 쿼리에 nickname 추가
- `SuccessCode.java` - 응답 코드 추가
- `ErrorCode.java` - PENALTY_NOT_FOUND 에러 코드 추가
